### PR TITLE
Modify regex to match json that includes newlines.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ export default class AutoClassifierPlugin extends Plugin {
 		// ------- [API Processing] -------
 		// Call API
 		const responseRaw = await ChatGPT.callAPI(system_role, user_prompt, this.settings.apiKey);
-		const jsonRegex = /reliability.*\s*:\s*([\d.]+).*output.*\s*:\s*"?([^"^}]+)/;
+		const jsonRegex = /reliability[\s\S]*?:\s*([\d.]+)[\s\S]*?output[\s\S]*?:\s*"([^"^}]+)/;
 		const match = responseRaw.match(jsonRegex);
 		let resOutput;
 		let resReliabity;


### PR DESCRIPTION
This fixes issue #20 

What seems to happen is that some queries return a single line, which causes no issues.
```
plugin:auto-classifier:587 {"reliability": 0.8, "output": "journal"}
```
Other times, it returns the same content but in a JSON format to include newline characters.
```
plugin:auto-classifier:587 {
"reliability": 0.9,
"output": "linux"
}
```
The raw response comes in the form of a (multi-line) string and not proper JSON. The existing regex does not allow for the newline characters, which is what I changed. 