### PR TITLE
Proposed change to support adding multiple tags

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -3,7 +3,7 @@ export const DEFAULT_PROMPT_TEMPLATE = `Classify this content:
 """
 {{input}}
 """
-Answer format is JSON {reliability:0~1, output:selected_category}. 
+Answer format is JSON Array [{reliability:0~1, output:selected_category}, ...]. 
 Even if you are not sure, qualify the reliability and select one. 
 Output must be one of these:
 


### PR DESCRIPTION
This has been requested a few times in "Issues" and would be very useful for me as well. This is not the final change but just wanted to use this PR to propose the basic skeleton of the change. It should be pretty simple, but we would need to tweak the prompt a bit to get ChatGPT to return a JSON array with multiple tags. We also should change the "Notice" functionality to not spam the user with notices every time a new tag is created, since multiple tags should create a lot of tags.

I'm not sure how to run the development environment to verify these changes but happy to help. Just wanted to get the ball rolling on this change. If we want to keep the existing functionality, we can maybe add a command/ setting option to allow to the users to enable "multi-tags" (BETA).