### PR TITLE
Fix JSON parse error when other GPT model used

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,7 @@ export default class AutoClassifierPlugin extends Plugin {
 		);
 		try {
 			try {
-				const response = JSON.parse(responseRaw);
+				const response = JSON.parse(responseRaw.replace(/^```json\n/, "").replace(/\n```$/, ""));
 				const resReliability = response.reliability;
 				const resOutputs = response.outputs;
 


### PR DESCRIPTION
Here's a quick fix to the issue: https://github.com/HyeonseoNam/auto-classifier/issues/34

GPT models after gpt-3.5-turbo have different output structure:

gpt-3.5-turbo: 
````
{
   "reliability": 0.9,
   "outputs":["Psychology", "CS"]
}
````

gpt-4o-mini:
````
```json
{
   "reliability": 0.9,
   "outputs":["Psychology", "CS"]
}
```
````
