### PR TITLE
fix: allowing multiple tags in title and frontmatter when overwrite is true

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -230,12 +230,12 @@ export default class AutoClassifierPlugin extends Plugin {
 			}
 
 			// ------- [Add Tags] -------
-			for (const resOutput of limitedOutputs) {
-				// Output Type 1. [Tag Case] + Output Type 2. [Wikilink Case]
-				if (
-					commandOption.outType == OutType.Tag ||
-					commandOption.outType == OutType.Wikilink
-				) {
+			// Output Type 1. [Tag Case] + Output Type 2. [Wikilink Case]
+			if (
+				commandOption.outType == OutType.Tag ||
+				commandOption.outType == OutType.Wikilink
+			) {
+				for (const resOutput of limitedOutputs) {
 					if (commandOption.outLocation == OutLocation.Cursor) {
 						this.viewManager.insertAtCursor(
 							resOutput,
@@ -244,7 +244,9 @@ export default class AutoClassifierPlugin extends Plugin {
 							commandOption.outPrefix,
 							commandOption.outSuffix,
 						);
-					} else if (commandOption.outLocation == OutLocation.ContentTop) {
+					} else if (
+						commandOption.outLocation == OutLocation.ContentTop
+					) {
 						this.viewManager.insertAtContentTop(
 							resOutput,
 							commandOption.outType,
@@ -253,25 +255,25 @@ export default class AutoClassifierPlugin extends Plugin {
 						);
 					}
 				}
-				// Output Type 3. [Frontmatter Case]
-				else if (commandOption.outType == OutType.FrontMatter) {
-					this.viewManager.insertAtFrontMatter(
-						commandOption.key,
-						resOutput,
-						commandOption.overwrite,
-						commandOption.outPrefix,
-						commandOption.outSuffix,
-					);
-				}
-				// Output Type 4. [Title]
-				else if (commandOption.outType == OutType.Title) {
-					this.viewManager.insertAtTitle(
-						resOutput,
-						commandOption.overwrite,
-						commandOption.outPrefix,
-						commandOption.outSuffix,
-					);
-				}
+			}
+			// Output Type 3. [Frontmatter Case]
+			else if (commandOption.outType == OutType.FrontMatter) {
+				this.viewManager.insertAtFrontMatter(
+					commandOption.key,
+					limitedOutputs,
+					commandOption.overwrite,
+					commandOption.outPrefix,
+					commandOption.outSuffix,
+				);
+			}
+			// Output Type 4. [Title]
+			else if (commandOption.outType == OutType.Title) {
+				this.viewManager.insertAtTitle(
+					limitedOutputs,
+					commandOption.overwrite,
+					commandOption.outPrefix,
+					commandOption.outSuffix,
+				);
 			}
 			// Show token usage if available
 			let tokenInfo = "";

--- a/src/view-manager.ts
+++ b/src/view-manager.ts
@@ -69,8 +69,8 @@ export class ViewManager {
         return tags;
     }
 
-    async insertAtFrontMatter(key: string, value: string, overwrite = false, prefix = '', suffix = ''): Promise<void> {
-        value = `${prefix}${value}${suffix}`;
+    async insertAtFrontMatter(key: string, values: string[], overwrite = false, prefix = '', suffix = ''): Promise<void> {
+        values = values.map((value) => `${prefix}${value}${suffix}`);
         const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
         
         if (activeView) {
@@ -81,27 +81,28 @@ export class ViewManager {
                 if (frontmatter[key] && !overwrite) {
                     // add value as list element if exist
                     if (Array.isArray(frontmatter[key])) {
-                        frontmatter[key].push(value);
+                        for (const value of values) 
+                            frontmatter[key].push(value);
                     } else {
-                        frontmatter[key] = [frontmatter[key], value];
+                        frontmatter[key] = [frontmatter[key], ...values];
                     }
                 } else {
                     // overwrite
-                    frontmatter[key] = value;
+                    frontmatter[key] = values;
                 }
             });
         }
     }
 
-    async insertAtTitle(value: string, overwrite = false, prefix = '', suffix = ''): Promise<void> {
-        value = `${prefix}${value}${suffix}`;
+    async insertAtTitle(values: string[], overwrite = false, prefix = '', suffix = ''): Promise<void> {
+        values = values.map((value) => `${prefix}${value}${suffix}`);
         const file = this.app.workspace.getActiveFile();
         if (!file) return; 
         let newName = file.basename;
         if (overwrite) {
-            newName = `${value}`;
+            newName = `${values.join(' ')}`;
         } else {
-            newName = `${newName} ${value}`;
+            newName = `${newName} ${values.join(' ')}`;
         }
         newName = newName.replace(/[\"\/<>:\|?\"]/g, ''); // for window file name
         // @ts-ignore


### PR DESCRIPTION
Previously, when `overwrite = true`, the code was doing something like:
```
for (const tag of tags) {
  remove old content
  set content = tag
}
```
Which resulted in only the last tag being added to the title or frontmatter

Now, the looping is handled internally in the frontmatter and title functions.